### PR TITLE
Ensure number sources searched info is accurate

### DIFF
--- a/components/block.js
+++ b/components/block.js
@@ -29,7 +29,7 @@ polarity.export = PolarityComponent.extend({
             value: isSourceActive(source.value, selectedSources)
           }))
       );
-      this.set('block.storage.numSourcesToSearch', this.get('block.storage.searchFilters.length'));
+      this.set('block.storage.numSourcesToSearch', this.getNumSourcesSearched());
     }
 
     let array = new Uint32Array(5);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "security-blogs",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "security-blogs",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "main": "./integration.js",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
If you ignore blogs from the integration option "Source to Ignore", the count of searched blogs in the details block is wrong on the first search.

This PR ensures the number of searched blogs is correct on init.